### PR TITLE
fix(sortable): overlay inside react portals & prop merging

### DIFF
--- a/docs/registry/default/ui/sortable.tsx
+++ b/docs/registry/default/ui/sortable.tsx
@@ -37,6 +37,7 @@ import * as React from "react";
 
 import { composeEventHandlers, composeRefs } from "@/lib/composition";
 import { cn } from "@/lib/utils";
+import { createPortal } from "react-dom";
 
 const orientationConfig = {
   vertical: {
@@ -283,7 +284,7 @@ function SortableOverlay(props: SortableOverlayProps) {
 
   const activeItem = context.items.find((item) => item.id === context.activeId);
 
-  return (
+  return createPortal(
     <DragOverlay
       modifiers={context.modifiers}
       dropAnimation={dropAnimationProp ?? dropAnimation}
@@ -301,7 +302,8 @@ function SortableOverlay(props: SortableOverlayProps) {
           )
         ) : null}
       </SortableOverlayContext.Provider>
-    </DragOverlay>
+    </DragOverlay>,
+    document.body,
   );
 }
 

--- a/docs/registry/default/ui/sortable.tsx
+++ b/docs/registry/default/ui/sortable.tsx
@@ -119,6 +119,11 @@ function Sortable<T extends UniqueItem>(props: SortableProps<T>) {
     onMove,
     orientation = "vertical",
     flatCursor = false,
+    // dnd-kit sortable props with overrides or defaults
+    accessibility,
+    onDragStart,
+    onDragEnd,
+    onDragCancel,
     ...sortableProps
   } = props;
   const id = React.useId();
@@ -162,11 +167,11 @@ function Sortable<T extends UniqueItem>(props: SortableProps<T>) {
         modifiers={modifiers ?? config.modifiers}
         sensors={sensorsProp ?? sensors}
         onDragStart={composeEventHandlers(
-          sortableProps.onDragStart,
+          onDragStart,
           ({ active }) => setActiveId(active.id),
         )}
         onDragEnd={composeEventHandlers(
-          sortableProps.onDragEnd,
+          onDragEnd,
           ({ active, over, activatorEvent, collisions, delta }) => {
             if (over && active.id !== over?.id) {
               const activeIndex = value.findIndex(
@@ -183,11 +188,12 @@ function Sortable<T extends UniqueItem>(props: SortableProps<T>) {
             setActiveId(null);
           },
         )}
-        onDragCancel={composeEventHandlers(sortableProps.onDragCancel, () =>
+        onDragCancel={composeEventHandlers(onDragCancel, () =>
           setActiveId(null),
         )}
         collisionDetection={collisionDetection ?? config.collisionDetection}
         accessibility={{
+          ...accessibility,
           announcements: {
             onDragStart({ active }) {
               return `Picked up sortable item ${active.id}. Use arrow keys to move, space to drop.`;
@@ -213,8 +219,8 @@ function Sortable<T extends UniqueItem>(props: SortableProps<T>) {
               }
               return `Sortable item ${active.id} is no longer over a droppable area`;
             },
+            ...accessibility?.announcements,
           },
-          ...sortableProps.accessibility,
         }}
         {...sortableProps}
       />

--- a/docs/registry/default/ui/sortable.tsx
+++ b/docs/registry/default/ui/sortable.tsx
@@ -439,7 +439,7 @@ const SortableItemGrip = React.forwardRef<
     />
   );
 });
-SortableItemGrip.displayName = "SortableItemGrip";
+SortableItemGrip.displayName = SORTABLE_ITEM_GRIP_NAME;
 
 const Root = Sortable;
 const Content = SortableContent;


### PR DESCRIPTION
## Fixes
1. Rendering the SortableOverlay inside a portal (e.g. radix popover) would render the overlay in a different location than expected. ([stackblitz repro & solution demo](https://stackblitz.com/~/github.com/gclark-eightfold/dice-ui-sortable-issue)) ([dnd-kit reference](https://docs.dndkit.com/api-documentation/draggable/drag-overlay#portals))
2. Event handlers `onDragStart`, `onDragEnd`, and `onDragCancel` would be overridden by the spreading of `{...sortableProps}` at the end of the component definition. This could also be resolved by moving the `{...sortableProps}` spreading *above* the event handlers, but I think destructing these from the props is generally a bit safer if/when others modify the code in their own codebases.
3. Similar to the above, but for the `accessibility` prop, but also made sure it can be a partial object without removing the established defaults.