### PR TITLE
fix(combobox): prevent item selection on Enter when list is empty

### DIFF
--- a/packages/combobox/src/combobox-input.tsx
+++ b/packages/combobox/src/combobox-input.tsx
@@ -197,7 +197,7 @@ const ComboboxInput = React.forwardRef<InputElement, ComboboxInputProps>(
               return;
             }
 
-            if (!context.highlightedItem) {
+            if (!context.highlightedItem || context.getIsListEmpty()) {
               if (!context.multiple && context.value) {
                 context.onInputValueChange(context.selectedText);
               } else {


### PR DESCRIPTION
fix: Combobox no longer selects items when list is empty **in "With Multiple Selection" example**

## Description
Fixed a bug where pressing Enter in the combobox when "no items found" was displayed would incorrectly select the last highlighted item from before the list became empty.

## Testing
1. Type text that results in "no items found"
2. Press Enter
3. Verify no item gets selected