### PR TITLE
fix: fix timestamp text alignment in relative date card

### DIFF
--- a/docs/registry/default/ui/relative-time-card.tsx
+++ b/docs/registry/default/ui/relative-time-card.tsx
@@ -218,18 +218,20 @@ const TimezoneCard = React.forwardRef<HTMLDivElement, TimezoneCardProps>(
         aria-label={`Time in ${timezoneName}: ${formattedDate} ${formattedTime}`}
         {...cardProps}
         ref={forwardedRef}
-        className="grid grid-cols-[auto_1fr_auto] items-center gap-2 text-muted-foreground text-sm"
+        className="flex items-center justify-between gap-2 text-muted-foreground text-sm"
       >
         <span className="w-fit rounded bg-accent px-1 font-medium text-xs">
           {timezoneName}
         </span>
-        <time dateTime={date.toISOString()}>{formattedDate}</time>
-        <time className="tabular-nums" dateTime={date.toISOString()}>
-          {formattedTime}
-        </time>
+        <div className="flex items-center gap-2">
+          <time dateTime={date.toISOString()}>{formattedDate}</time>
+          <time className="tabular-nums" dateTime={date.toISOString()}>
+            {formattedTime}
+          </time>
+        </div>
       </div>
     );
-  },
+  }
 );
 TimezoneCard.displayName = "TimezoneCard";
 


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/0802a059-b5b4-454c-9d33-14c5298ba168)

After:
![after](https://github.com/user-attachments/assets/c505d2da-0d10-4c22-923b-5530ba971f83)
