### PR TITLE
Fix for Incorrect Combobox Input Search Filtering for Combobox Group

### DIFF
--- a/packages/shared/src/hooks/use-filter-store.ts
+++ b/packages/shared/src/hooks/use-filter-store.ts
@@ -123,9 +123,11 @@ function useFilterStore<
       const matchingItems = new Set(filterStore.items.keys());
 
       for (const [groupId, group] of groupMap) {
-        const hasMatchingItem = Array.from(group).some((ref) =>
-          matchingItems.has(ref.current?.id ?? ""),
-        );
+        const hasMatchingItem = Array.from(group).some((ref) => {
+          const item = itemMap.get(ref as React.RefObject<TElement | null>);
+          const value = item?.value ?? "";
+          return matchingItems.has(value);
+        });
 
         if (hasMatchingItem) {
           filterStore.groups.set(groupId, new Set());

--- a/packages/shared/test/use-filter-store.test.ts
+++ b/packages/shared/test/use-filter-store.test.ts
@@ -141,6 +141,27 @@ describe("useFilterStore", () => {
     expect(result.current.filterStore.groups?.has("expert")).toBe(false);
   });
 
+  it("handles group filtering when ref ids differ from item values", () => {
+    // Build itemMap with refs whose current.id != value
+    itemMap.clear();
+    const refA = { current: { id: "dom-1" } } as React.RefObject<HTMLElement>;
+    const refB = { current: { id: "dom-2" } } as React.RefObject<HTMLElement>;
+    itemMap.set(refA, { value: "Kickflip", ref: refA });
+    itemMap.set(refB, { value: "Heelflip", ref: refB });
+
+    // Group contains those refs
+    groupMap.clear();
+    groupMap.set("advanced", new Set([refA, refB]));
+
+    const { result } = renderHook(() => useFilterStore({ itemMap, groupMap }));
+
+    result.current.filterStore.search = "Kickflip";
+    result.current.onItemsFilter();
+
+    expect(result.current.filterStore.itemCount).toBe(1);
+    expect(result.current.filterStore.items.has("Kickflip")).toBe(true);
+  });
+
   it("respects manual filtering flag", () => {
     const { result } = renderHook(() =>
       useFilterStore({ itemMap, manualFiltering: true }),


### PR DESCRIPTION
Combobox groups were not showing/hiding correctly when filtering. 

### Steps to Reproduce

1. Go to https://www.diceui.com/docs/components/combobox#with-groups
2. Search for any trick/option.
3. Dropdown does not render correctly.

https://github.com/user-attachments/assets/bf246f75-6994-4c74-9eaf-e60fc55442d2

### Root Cause 

Groups with matching items remained hidden because group matching compared DOM ids to item values instead of resolving refs to the items' values.

### Fix 

1. Resolve each ref in a group back to the CollectionItem via `itemMap`, read the item's `.value`, and check that value against `filterStore.items` keys.
2. This ensures group matching uses item values (same domain as `filterStore.items`) rather than DOM ids.


https://github.com/user-attachments/assets/f38406b6-2748-458c-a718-409d9948294c

