### PR TITLE
fix(ui): center main section content and enhance hero heading typography

### DIFF
--- a/docs/app/(lobby)/layout.tsx
+++ b/docs/app/(lobby)/layout.tsx
@@ -10,7 +10,7 @@ export default function IndexLayout({ children }: IndexLayoutProps) {
   return (
     <div className="relative flex min-h-screen flex-col">
       <HomeLayout {...baseOptions}>
-        <main className="flex-1">{children}</main>
+        <main className="flex flex-1 items-center">{children}</main>
         <SiteFooter />
       </HomeLayout>
     </div>

--- a/docs/app/(lobby)/page.tsx
+++ b/docs/app/(lobby)/page.tsx
@@ -8,7 +8,7 @@ export default function IndexPage() {
     <section className="container flex flex-col items-center justify-center gap-6 pt-6 pb-8 md:py-10">
       <div className="flex max-w-5xl flex-col items-center gap-4">
         <h1
-          className="animate-fade-up text-balance bg-linear-to-br from-foreground/80 to-muted-foreground bg-clip-text text-center font-bold text-4xl/tight text-transparent leading-tight tracking-tighter opacity-0 drop-shadow-xs md:text-5xl/tight"
+          className="animate-fade-up text-balance bg-linear-to-br from-foreground/80 to-muted-foreground bg-clip-text text-center font-bold text-4xl/tight text-transparent leading-tight tracking-tighter opacity-0 drop-shadow-xs md:text-5xl/tight lg:text-6xl/tight"
           style={{ animationDelay: "0.20s", animationFillMode: "forwards" }}
         >
           Accessible components for shadcn/ui


### PR DESCRIPTION

## Summary

This PR fixes the vertical and horizontal centering issue in the main layout and improves the visual hierarchy of the hero heading on large screens.

---

## ✅ Changes Made

### Layout Fix

Added missing `flex` class to the `<main>` element inside the layout file to ensure proper centering of child elements.
/docs/app/(lobby)/layout.tsx
```diff
- <main className="flex-1">
+ <main className="flex flex-1 items-center">
```
### Typography Improvement
/docs/app/(lobby)/page.tsx

```diff
+ <h1 className="lg:text-6xl/tight"></h1>
```

### Before :
<img width="1470" height="838" alt="2025-10-30_15-44-21" src="https://github.com/user-attachments/assets/f3f7f780-f523-4bc7-aa65-ef3fd0560a40" />



### After :
<img width="1470" height="779" alt="2025-10-30_15-44-10" src="https://github.com/user-attachments/assets/29a3bbf9-b404-41b4-a00e-0ab43aa6d7b4" />

### Tools Used :
Brave Browser , VsCode 
