### PR TITLE
mention: Add input element support and demo

### DIFF
--- a/docs/__registry__/index.tsx
+++ b/docs/__registry__/index.tsx
@@ -1645,6 +1645,20 @@ export const Index: Record<string, any> = {
       source: "",
       chunks: []
     },
+    "mention-input-demo": {
+      name: "mention-input-demo",
+      description: "",
+      type: "registry:example",
+      registryDependencies: undefined,
+      files: [{
+        path: "registry/default/examples/mention-input-demo.tsx",
+        type: "registry:example",
+        target: ""
+      }],
+      component: React.lazy(() => import("@/registry/default/examples/mention-input-demo.tsx")),
+      source: "",
+      chunks: []
+    },
     "qr-code-demo": {
       name: "qr-code-demo",
       description: "",

--- a/docs/content/docs/components/mention.mdx
+++ b/docs/content/docs/components/mention.mdx
@@ -67,6 +67,10 @@ import * as Mention from "@diceui/mention";
 
 <ComponentTabs name="mention-custom-filter-demo" />
 
+### With Input Component
+
+<ComponentTabs name="mention-input-demo" />
+
 ## API Reference
 
 ### Root

--- a/docs/public/r/styles/default/mention-input-demo.json
+++ b/docs/public/r/styles/default/mention-input-demo.json
@@ -1,0 +1,16 @@
+{
+  "name": "mention-input-demo",
+  "type": "registry:example",
+  "dependencies": [
+    "@diceui/mention",
+    "lucide-react"
+  ],
+  "files": [
+    {
+      "path": "examples/mention-input-demo.tsx",
+      "content": "\"use client\";\n\nimport * as React from \"react\";\nimport {\n  Mention,\n  MentionContent,\n  MentionInput,\n  MentionItem,\n} from \"@/registry/default/ui/mention\";\nimport { Input } from \"@/components/ui/input\";\n\nconst commands = [\n  {\n    id: \"1\",\n    name: \"help\",\n    description: \"Show available commands\",\n  },\n  {\n    id: \"2\",\n    name: \"clear\",\n    description: \"Clear the console\",\n  },\n  {\n    id: \"3\",\n    name: \"restart\",\n    description: \"Restart the application\",\n  },\n  {\n    id: \"4\",\n    name: \"reload\",\n    description: \"Reload the current page\",\n  },\n  {\n    id: \"5\",\n    name: \"quit\",\n    description: \"Exit the application\",\n  },\n];\n\nexport default function MentionInputDemo() {\n  const [value, setValue] = React.useState<string[]>([]);\n  const [inputValue, setInputValue] = React.useState(\"\");\n\n  // Custom filter that matches commands starting with the search term\n  function onFilter(options: string[], term: string) {\n    return options.filter((option) =>\n      option.toLowerCase().startsWith(term.toLowerCase()),\n    );\n  }\n\n  return (\n    <Mention\n      value={value}\n      onValueChange={setValue}\n      inputValue={inputValue}\n      onInputValueChange={setInputValue}\n      trigger=\"/\"\n      onFilter={onFilter}\n      className=\"w-full max-w-[400px]\"\n    >\n      <MentionInput placeholder=\"Type / to use a command...\" asChild>\n        <Input />\n      </MentionInput>\n      <MentionContent>\n        {commands.map((command) => (\n          <MentionItem\n            key={command.id}\n            label={command.name}\n            value={command.name}\n          >\n            <span className=\"font-mono text-sm\">{command.name}</span>\n            <span className=\"text-muted-foreground text-xs\">\n              {command.description}\n            </span>\n          </MentionItem>\n        ))}\n      </MentionContent>\n    </Mention>\n  );\n}\n",
+      "type": "registry:example",
+      "target": ""
+    }
+  ]
+}

--- a/docs/registry/default/examples/mention-input-demo.tsx
+++ b/docs/registry/default/examples/mention-input-demo.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import * as React from "react";
+import {
+  Mention,
+  MentionContent,
+  MentionInput,
+  MentionItem,
+} from "@/registry/default/ui/mention";
+import { Input } from "@/components/ui/input";
+
+const commands = [
+  {
+    id: "1",
+    name: "help",
+    description: "Show available commands",
+  },
+  {
+    id: "2",
+    name: "clear",
+    description: "Clear the console",
+  },
+  {
+    id: "3",
+    name: "restart",
+    description: "Restart the application",
+  },
+  {
+    id: "4",
+    name: "reload",
+    description: "Reload the current page",
+  },
+  {
+    id: "5",
+    name: "quit",
+    description: "Exit the application",
+  },
+];
+
+export default function MentionInputDemo() {
+  const [value, setValue] = React.useState<string[]>([]);
+  const [inputValue, setInputValue] = React.useState("");
+
+  function onFilter(options: string[], term: string) {
+    return options.filter((option) =>
+      option.toLowerCase().startsWith(term.toLowerCase()),
+    );
+  }
+
+  return (
+    <Mention
+      value={value}
+      onValueChange={setValue}
+      inputValue={inputValue}
+      onInputValueChange={setInputValue}
+      trigger="/"
+      onFilter={onFilter}
+      className="w-full max-w-[400px]"
+    >
+      <MentionInput placeholder="Type / to use a command..." asChild>
+        <Input />
+      </MentionInput>
+      <MentionContent>
+        {commands.map((command) => (
+          <MentionItem
+            key={command.id}
+            label={command.name}
+            value={command.name}
+          >
+            <span className="font-mono text-sm">{command.name}</span>
+            <span className="text-muted-foreground text-xs">
+              {command.description}
+            </span>
+          </MentionItem>
+        ))}
+      </MentionContent>
+    </Mention>
+  );
+}

--- a/docs/registry/registry-examples.ts
+++ b/docs/registry/registry-examples.ts
@@ -1016,6 +1016,17 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "mention-input-demo",
+    type: "registry:example",
+    dependencies: ["@diceui/mention", "lucide-react"],
+    files: [
+      {
+        path: "examples/mention-input-demo.tsx",
+        type: "registry:example",
+      },
+    ],
+  },
+  {
     name: "qr-code-demo",
     type: "registry:example",
     registryDependencies: ["qr-code"],

--- a/packages/mention/src/mention-highlighter.tsx
+++ b/packages/mention/src/mention-highlighter.tsx
@@ -32,6 +32,7 @@ const MentionHighlighter = React.memo(
       const highlighterRef = React.useRef<HighlighterElement>(null);
       const composedRef = useComposedRefs(forwardedRef, highlighterRef);
       const [inputStyle, setInputStyle] = React.useState<CSSStyleDeclaration>();
+      const [isInputElement, setIsInputElement] = React.useState<boolean>(false);
       const onInputStyleChangeCallback = useCallbackRef(setInputStyle);
 
       const onInputStyleChange = React.useCallback(() => {
@@ -39,6 +40,8 @@ const MentionHighlighter = React.memo(
         if (!inputElement) return;
 
         const computedStyle = window.getComputedStyle(inputElement);
+        const isInput = inputElement.tagName === "INPUT";
+        setIsInputElement(isInput);
         onInputStyleChangeCallback(computedStyle);
       }, [context.inputRef, onInputStyleChangeCallback]);
 
@@ -103,7 +106,7 @@ const MentionHighlighter = React.memo(
       const highlighterStyle = React.useMemo<React.CSSProperties>(() => {
         if (!inputStyle) return defaultHighlighterStyle;
 
-        return {
+        const baseStyle = {
           ...defaultHighlighterStyle,
           fontStyle: inputStyle.fontStyle,
           fontVariant: inputStyle.fontVariant,
@@ -127,7 +130,19 @@ const MentionHighlighter = React.memo(
           direction: context.dir,
           ...style,
         };
-      }, [inputStyle, style, context.dir]);
+
+        if (isInputElement) {
+          return {
+            ...baseStyle,
+            whiteSpace: "nowrap",
+            overflowX: "auto",
+            overflowY: "hidden",
+            wordWrap: "normal",
+          };
+        }
+
+        return baseStyle;
+      }, [inputStyle, style, context.dir, isInputElement]);
 
       const onSegmentsRender = React.useCallback(() => {
         const inputElement = context.inputRef.current;


### PR DESCRIPTION
Add support for using Mention component with native Input elements and provide a demo example.

This PR adds improved styling support for INPUT elements in the MentionHighlighter component and includes a new demo showcasing how to use MentionInput with the Input component.

- Enhanced MentionHighlighter to detect and properly style INPUT elements with appropriate overflow handling
- Added mention-input-demo example demonstrating MentionInput usage with Input component
- Updated documentation to include the new demo example