### PR TITLE
feat: update TOC style

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -48,7 +48,7 @@ export default async function DocPage(props: DocPageParams) {
   const apiLink = page.data.links?.api;
 
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
+    <DocsPage toc={page.data.toc} tableOfContent={{style: "clerk"}} full={page.data.full}>
       <div className="flex flex-col gap-2">
         <DocsTitle>{page.data.title}</DocsTitle>
         <DocsDescription className="mb-2.5">


### PR DESCRIPTION
Tiny visual upgrade to the Table of content, feels cleaner than the default.

### Before:
<img width="303" height="726" alt="Screenshot 2025-11-29 at 10 42 40 PM" src="https://github.com/user-attachments/assets/feef7b97-2776-41cd-b5f0-3f5f6851e14c" />

### After:
<img width="297" height="725" alt="Screenshot 2025-11-29 at 10 40 17 PM" src="https://github.com/user-attachments/assets/6ac36218-dcc7-45ab-ad33-57d2820f4bc5" />
