### PR TITLE
chore(workspace): disable eslint and oxc extensions for workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,8 @@
   },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "biomejs.biome",
+  "eslint.enable": false,
+  "oxc.enable": false,
   "tailwindCSS.validate": true,
   "tailwindCSS.lint.cssConflict": "ignore",
   "tailwindCSS.experimental.classRegex": [


### PR DESCRIPTION
This project uses Biome for linting and formatting, so disable other linter extensions in workspace settings to prevent conflicts.