### PR TITLE
fix(mention): Reset mentions array on value clear

### DIFF
--- a/packages/mention/src/mention-root.tsx
+++ b/packages/mention/src/mention-root.tsx
@@ -234,6 +234,14 @@ const MentionRoot = React.forwardRef<RootElement, MentionRootProps>(
     const [mentions, setMentions] = React.useState<Mention[]>([]);
     const [isPasting, setIsPasting] = React.useState(false);
 
+    // Reset mentions array when value is cleared
+    React4.useEffect(() => {
+      // If there are no selected values but mentions still exist, clear them
+      if (value.length === 0 && mentions.length > 0) {
+        setMentions([]);
+      }
+    }, [value, mentions]);
+
     const { filterStore, onItemsFilter, getIsItemVisible } = useFilterStore({
       itemMap,
       onFilter,


### PR DESCRIPTION
### What the change does:
1. Monitors input value changes : The effect runs whenever the value or mentions state changes.
2. Detects empty value state : When the currently selected value is cleared (length === 0) but the mentions array still contains items.
3. Resets mentions array : Automatically clears the mentions array in this scenario to prevent stale data from persisting.
### Why this is necessary:
Previously, if users cleared the currently selected value completely, the mentions array would retain its previous values, leading to inconsistent state and potential unexpected behavior (e.g., mentions still being processed or displayed despite an empty input). This fix ensures the mentions state always reflects the current input context, maintaining data integrity between the currently selected value and associated mentions.