### PR TITLE
fix(ci): skip docs build in release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           version: 10.22.0
       - uses: ./.github/setup
 
-      - name: Build packages (excluding docs)
+      - name: Build packages
         run: pnpm turbo build --filter=!docs
 
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: ./.github/setup
 
       - name: Build
-        run: pnpm build
+        run: pnpm turbo build --filter=!docs
 
       - name: Create Release
         id: changesets


### PR DESCRIPTION
## Summary

- Updated release workflow to exclude docs package from build step using --filter=!docs
- Aligns with CI workflow approach where docs are intentionally skipped
- Fixes release workflow failure caused by fumadocs-mdx content generation

## Context

The release workflow was failing at the docs:generate:content step. Since docs are built separately on Vercel during deployment, there's no need to build them in the release workflow.

## Changes

- Modified .github/workflows/release.yml to use pnpm turbo build --filter=!docs
- Updated .github/workflows/main.yml step name for consistency