### PR TITLE
fix: consistent horizontal padding in code blocks

### DIFF
--- a/docs/styles/globals.css
+++ b/docs/styles/globals.css
@@ -346,6 +346,10 @@
     @apply bg-secondary/50!;
   }
 
+  [data-rehype-pretty-code-figure] pre {
+    padding-inline: calc(var(--spacing) * 3.5) !important;
+  }
+  
   [data-line] span {
     @apply text-(--shiki-light) dark:text-(--shiki-dark);
   }


### PR DESCRIPTION
Hi! I’m a final-year student exploring open source and really enjoyed working with this codebase ... great job on the project

This PR fixes a visual inconsistency in code block spacing.

### Problem
- Code blocks use utility classes (`py-3.5`) which apply equal spacing via `padding-inline`
- However, `rehype-pretty-code` injects an inline `padding-right`, overriding the right side
- This results in uneven horizontal spacing (right side appears larger than left)

### Solution
- Override padding using `[data-rehype-pretty-code-figure] pre`
- Enforce consistent horizontal spacing with `padding-inline` so both left and right stay aligned

### Before
<img width="884" height="130" alt="before" src="https://github.com/user-attachments/assets/c3b6b9e1-1d94-49aa-a02e-8c42b2aba9e8" />

### After
<img width="870" height="120" alt="after" src="https://github.com/user-attachments/assets/9368970b-c390-4d0a-b298-07a5cfe6f4fb" />


This ensures visual consistency while preserving the design system. 

I initially didn’t notice this as a bug, but after comparing it with other pages, the misalignment became clear.