### PR TITLE
fix(docs): redirect use-data-grid-* registry items to tablecn

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -28,7 +28,8 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
       {
-        source: "/r/:component(data-table.*\\.json|data-grid.*\\.json)",
+        source:
+          "/r/:component(data-table.*\\.json|data-grid.*\\.json|use-data-grid.*\\.json)",
         destination: "https://tablecn.com/r/:component",
         permanent: true,
       },


### PR DESCRIPTION
Fixes sadmann7/tablecn#1142

## Problem

`pnpm dlx shadcn@latest add @diceui/use-data-grid-undo-redo` fails with a 404:

```
The item at https://diceui.com/r/use-data-grid-undo-redo.json was not found.
```

The file itself exists and is served fine by tablecn (`https://tablecn.com/r/use-data-grid-undo-redo.json` returns 200). The issue is in the redirect rule in `docs/next.config.ts`, which forwards data grid registry items to tablecn:

```ts
source: "/r/:component(data-table.*\\.json|data-grid.*\\.json)",
```

The new hook is named `use-data-grid-undo-redo`, so it doesn't match either alternative. The request falls through to the flat rewrite (`/r/:name.json` → `/r/styles/radix-vega/:name.json`), and since the item doesn't exist in the local registry, it 404s.

## Fix

Add `use-data-grid.*\.json` as a third alternative to the redirect pattern. It's kept narrow on purpose so diceui's own hooks (`use-mobile`, `use-as-ref`, `use-lazy-ref`, etc.) keep resolving from the local registry. Any future `use-data-grid-*` hooks published by tablecn will be covered as well.

## Verification

Tested the pattern with `path-to-regexp` (the matcher Next.js uses for `redirects()`):

| Path | Result |
| --- | --- |
| `/r/use-data-grid-undo-redo.json` | redirected to tablecn ✅ |
| `/r/data-grid.json` | redirected to tablecn (unchanged) |
| `/r/data-table-filter-list.json` | redirected to tablecn (unchanged) |
| `/r/use-mobile.json` | falls through to local registry (unchanged) |
| `/r/use-as-ref.json` | falls through to local registry (unchanged) |
| `/r/radix-vega/data-grid-demo.json` | falls through to rewrites (unchanged) |
