### PR TITLE
fix(hitbox): make base variant hitbox clickable

### DIFF
--- a/docs/registry/bases/base/components/hitbox.tsx
+++ b/docs/registry/bases/base/components/hitbox.tsx
@@ -1,6 +1,6 @@
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -19,18 +19,17 @@ const hitboxVariants = cva(
         lg: "[--size:var(--size-lg)]",
         dynamic: "[--size:var(--size)]",
       },
+      // Inset utilities (not arbitrary properties) so tailwind-merge can
+      // override the slotted child's own after:inset-* classes, e.g. the
+      // checkbox touch target.
       position: {
-        all: "after:[inset:calc(-1*var(--size))]",
-        top: "after:[height:var(--size)] after:[left:0] after:[right:0] after:[top:calc(-1*var(--size))]",
-        bottom:
-          "after:[bottom:calc(-1*var(--size))] after:[height:var(--size)] after:[left:0] after:[right:0]",
-        left: "after:[bottom:0] after:[left:calc(-1*var(--size))] after:[top:0] after:[width:var(--size)]",
-        right:
-          "after:[bottom:0] after:[right:calc(-1*var(--size))] after:[top:0] after:[width:var(--size)]",
-        vertical:
-          "after:[bottom:calc(-1*var(--size))] after:[left:0] after:[right:0] after:[top:calc(-1*var(--size))]",
-        horizontal:
-          "after:[bottom:0] after:[left:calc(-1*var(--size))] after:[right:calc(-1*var(--size))] after:[top:0]",
+        all: "after:inset-[calc(-1*var(--size))]",
+        top: "after:inset-[calc(-1*var(--size))_0_100%]",
+        bottom: "after:inset-[100%_0_calc(-1*var(--size))]",
+        left: "after:inset-[0_100%_0_calc(-1*var(--size))]",
+        right: "after:inset-[0_calc(-1*var(--size))_0_100%]",
+        vertical: "after:inset-[calc(-1*var(--size))_0]",
+        horizontal: "after:inset-[0_calc(-1*var(--size))]",
       },
       radius: {
         none: "",
@@ -68,14 +67,22 @@ function Hitbox(props: HitboxProps) {
     radius,
     debug = false,
     render,
+    children,
     ...hitboxProps
   } = props;
 
   const isDynamicSize = size && !sizes.includes(size);
 
+  // Merge onto a single element child (like Radix Slot) so the ::after
+  // hit area belongs to the interactive element instead of a wrapper div
+  // that would intercept its clicks.
+  const childAsRender =
+    !render && React.isValidElement(children) ? children : undefined;
+
   return useRender({
     props: {
       ...hitboxProps,
+      ...(childAsRender ? {} : { children }),
       className: cn(
         hitboxVariants({
           size: isDynamicSize ? "dynamic" : (size as Size),
@@ -90,7 +97,7 @@ function Hitbox(props: HitboxProps) {
         ...style,
       } as React.CSSProperties,
     },
-    render,
+    render: render ?? childAsRender,
     state: {
       slot: "hitbox",
     },


### PR DESCRIPTION
Fixes #289

## Problem

In the Base UI variant, checkboxes wrapped in `<Hitbox>` are not clickable at all — neither the checkbox itself nor the extended hitbox area (reproducible on https://diceui.com/docs/utilities/base/hitbox).

The radix variant merges the hitbox classes onto the child via `Slot`, so the `::after` hit area belongs to the checkbox button itself. The base variant passes the checkbox as `children`, and `useRender` without a `render` prop renders a **wrapper `div`**. The wrapper's positioned `::after` (`inset: -12px`) paints above the static child and intercepts every click — the click target becomes the div, which does nothing.

## Fix

Two parts, both in `docs/registry/bases/base/components/hitbox.tsx`:

**1. Merge onto a single element child** (matching the radix variant's `Slot` behavior): when no `render` prop is given and `children` is a single valid element, use it as the `useRender` render target. Explicit `render` and non-element children behave exactly as before, and the documented `<Hitbox><Checkbox /></Hitbox>` usage keeps working.

**2. Rewrite position variants as inset utilities instead of arbitrary properties.** Once the hitbox classes land on the checkbox itself, they collide with the checkbox's own built-in touch target (`after:-inset-x-3 after:-inset-y-2`). tailwind-merge can't reconcile arbitrary properties like `after:[inset:calc(…)]` with those utilities, so both survived and stylesheet order decided the outcome — the debug area rendered as a rectangle and `position="bottom"` extended upward. Arbitrary-*value* inset utilities (`after:inset-[calc(-1*var(--size))]`) belong to tw-merge's `inset` group, which correctly overrides the child's `inset-x`/`inset-y` classes. As a bonus, every position variant is now a single class:

```ts
position: {
  all: "after:inset-[calc(-1*var(--size))]",
  top: "after:inset-[calc(-1*var(--size))_0_100%]",
  bottom: "after:inset-[100%_0_calc(-1*var(--size))]",
  left: "after:inset-[0_100%_0_calc(-1*var(--size))]",
  right: "after:inset-[0_calc(-1*var(--size))_0_100%]",
  vertical: "after:inset-[calc(-1*var(--size))_0]",
  horizontal: "after:inset-[0_calc(-1*var(--size))]",
},
```

(`bottom: 100%` pins the pseudo-element's bottom edge to the element's top and vice versa, so the side strips need no width/height.)

## Verification (local docs site)

- DOM: no wrapper divs left — every `data-slot="hitbox"` element on the demo page is the checkbox itself, with the checkbox's own `after:-inset-x-3 after:-inset-y-2` correctly merged away.
- Computed `::after` styles: `all` → `-12px` on all sides, `radius="full"` → circle, `bottom` → strip strictly below the element.
- Clicks: center of the checkbox toggles; 8px outside its edge (inside the hitbox) toggles; for `position="bottom"`, a click below toggles while a click above does not.
- All 7 position variants and the sizes/radii/debug demos render identically to the current production page.
- `tsc --noEmit` and `biome check` pass.

## Notes

- The `Pending` (base) utility has the same wrapper-div pattern, so its click/keydown `preventDefault` guards likely never reach the wrapped button. Left out of scope here — happy to open a separate issue/PR.
