### PR TITLE
fix(key-value): match base value input height to key input

### DIFF
--- a/docs/registry/bases/base/ui/key-value.tsx
+++ b/docs/registry/bases/base/ui/key-value.tsx
@@ -633,7 +633,7 @@ function KeyValueValueInput(props: KeyValueValueInputProps) {
   const isReadOnly = readOnly || context.readOnly;
   const isRequired = required || context.required;
   const isInvalid = errors[itemData.id]?.value !== undefined;
-  const maxHeight = maxRows ? `calc(${maxRows} * 1.5em + 1rem)` : undefined;
+  const maxHeight = maxRows ? `calc(${maxRows} * 1.5em + 0.5rem)` : undefined;
 
   const onChange = React.useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -708,7 +708,7 @@ function KeyValueValueInput(props: KeyValueValueInputProps) {
       placeholder={context.valuePlaceholder}
       {...valueInputProps}
       className={cn(
-        "field-sizing-content min-h-9 resize-none",
+        "field-sizing-content min-h-8 resize-none py-1",
         maxRows && "overflow-y-auto",
         className,
       )}


### PR DESCRIPTION
Fixes #288

## Problem

On https://diceui.com/docs/components/base/key-value the key and value fields render at different heights: the key `Input` is 32px while the value `Textarea` is 38px.

The value input's `min-h-9` was carried over from the radix variant, where the `Input` is `h-9`. In the base design the `Input` is `h-8` with `py-1`, while the base `Textarea` has `py-2` — and since the textarea is `field-sizing-content`, its single-line height is driven by content + padding (20px line + 16px padding + 2px border = 38px), overflowing past `min-h` entirely.

## Fix

Two lines in `docs/registry/bases/base/ui/key-value.tsx`:

- Value textarea overrides: `min-h-9` → `min-h-8 py-1`, mirroring the base `Input` metrics (`h-8 py-1`). A single-line value field now clamps to exactly 32px.
- The `maxRows` max-height formula reserved `1rem` for vertical padding (matching the old `py-2`); adjusted to `0.5rem` for `py-1` so the row clamp stays accurate.

## Verification (local docs site)

- Key and value fields both measure exactly 32px (previously 32px vs 38px).
- Auto-grow still works: three lines of content → 70px, clearing the field returns it to 32px.
- Fields align with each other and the remove button in the demo.
- `tsc --noEmit` and `biome check` pass.

Note: the radix variant has its own much subtler mismatch (36px input vs 38px textarea, the same `py-2` overflow past `min-h-9`) — left untouched here, happy to align it in a follow-up if desired.
